### PR TITLE
feat: add audio output selection (Mac / Phone / Mute)

### DIFF
--- a/App/Scenes/MirrorWindow.swift
+++ b/App/Scenes/MirrorWindow.swift
@@ -21,6 +21,11 @@ final class MirrorWindowController: NSWindowController {
   private var isRecording = false
   private var isClipboardSyncing = true     // default ON, AndroMeld-style
   private var isScreenOff = false
+  /// "mac" | "phone" | "none" — persisted in UserDefaults
+  private var audioOutput: String {
+    get { UserDefaults.standard.string(forKey: "mirror.audioOutput") ?? "mac" }
+    set { UserDefaults.standard.set(newValue, forKey: "mirror.audioOutput") }
+  }
   private var clipboardBridge: ClipboardBridge?
   private let deviceDisplayName: String
 
@@ -310,12 +315,24 @@ final class MirrorWindowController: NSWindowController {
     clipboardBridge?.enabled = isClipboardSyncing
   }
 
+  /// Cycle audio output: mac → phone → none → mac
+  @objc private func cycleAudioOutput() {
+    let next: String
+    switch audioOutput {
+    case "mac":   next = "phone"
+    case "phone": next = "none"
+    default:      next = "mac"
+    }
+    audioOutput = next
+  }
+
   @objc private func toggleScreenOff() {
     isScreenOff.toggle()
-    let mode: UInt8 = isScreenOff ? 0 : 2
     Task {
       if let writer = await session.control {
-        try? await writer.send(.setScreenPowerMode(mode))
+        // Use KEYCODE_POWER for true screen on/off
+        try? await writer.send(.keycode(26, action: .down))
+        try? await writer.send(.keycode(26, action: .up))
       }
     }
   }
@@ -359,7 +376,8 @@ final class MirrorWindowController: NSWindowController {
         isRecording: isRecording,
         isClipboardSyncing: isClipboardSyncing,
         isScreenOff: isScreenOff,
-        isPinned: isPinned
+        isPinned: isPinned,
+        audioOutput: audioOutput
       ),
       onBack:       { [weak self] in dismiss(); self?.sendBack() },
       onHome:       { [weak self] in dismiss(); self?.sendHome() },
@@ -370,7 +388,8 @@ final class MirrorWindowController: NSWindowController {
       onClipboard:  { [weak self] in dismiss(); self?.toggleClipboardSync() },
       onScreenOff:  { [weak self] in dismiss(); self?.toggleScreenOff() },
       onWake:       { [weak self] in dismiss(); self?.wakeDevice() },
-      onPin:        { [weak self] in dismiss(); self?.togglePin() }
+      onPin:        { [weak self] in dismiss(); self?.togglePin() },
+      onCycleAudio: { [weak self] in dismiss(); self?.cycleAudioOutput() }
     )
     let hosting = NSHostingController(rootView: panel)
     popover.contentViewController = hosting
@@ -542,6 +561,7 @@ struct MoreActionsPanel: View {
     var isClipboardSyncing: Bool
     var isScreenOff: Bool
     var isPinned: Bool
+    var audioOutput: String  // "mac" | "phone" | "none"
   }
 
   let state: State
@@ -555,6 +575,23 @@ struct MoreActionsPanel: View {
   let onScreenOff: () -> Void
   let onWake: () -> Void
   let onPin: () -> Void
+  let onCycleAudio: () -> Void
+
+  var audioLabel: String {
+    switch state.audioOutput {
+    case "mac":   return "Mac"
+    case "phone": return "Phone"
+    default:      return "Mute"
+    }
+  }
+
+  var audioSymbol: String {
+    switch state.audioOutput {
+    case "mac":   return "speaker.wave.3.fill"
+    case "phone": return "iphone.gen2"
+    default:      return "speaker.slash.fill"
+    }
+  }
 
   var body: some View {
     VStack(spacing: 8) {
@@ -580,6 +617,9 @@ struct MoreActionsPanel: View {
              label: state.isScreenOff ? "Wake" : "Sleep",
              tint: state.isScreenOff ? .yellow : nil,
              action: onScreenOff)
+        Tile(symbol: audioSymbol, label: audioLabel, action: onCycleAudio)
+      }
+      HStack(spacing: 8) {
         Tile(symbol: "power", label: "Power", action: onWake)
         Tile(symbol: state.isPinned ? "pin.fill" : "pin",
              label: "Pin",

--- a/App/Scenes/MirrorWindow.swift
+++ b/App/Scenes/MirrorWindow.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ADBKit
 import CoreVideo
 import CoreMedia
 import MirrorEngine
@@ -29,6 +30,15 @@ final class MirrorWindowController: NSWindowController {
   private var clipboardBridge: ClipboardBridge?
   private let deviceDisplayName: String
 
+  // Screen-state poller — keeps `isScreenOff` in sync with the phone's real
+  // display state so the UI doesn't drift after the user manually unlocks.
+  private let adb = ADBClient()
+  private var screenStatePoller: Timer?
+  private var autoScreenOffEnabled = false   // whether the user wants auto-off
+  /// Device media volume saved before we muted it — restored when switching
+  /// back to "phone" mode so we don't leave the phone permanently silent.
+  private var savedDeviceVolume: Int?
+
   // iPhone-Mirroring-style chrome auto-hide.
   private var chromeRevealed = false
   private var chromeHideTimer: Timer?
@@ -42,6 +52,10 @@ final class MirrorWindowController: NSWindowController {
 
   /// Set by SessionCoordinator after the controller is created.
   var deviceSerial: String?
+  /// True while the session is being torn down and relaunched (audio mode
+  /// change). Prevents `bindControl()` from re-applying audio / auto-screen-off
+  /// on the fresh session so the window keeps its current state.
+  var isRestarting = false
 
   init(deviceName: String) throws {
     let renderer = try MetalFrameRenderer()
@@ -157,6 +171,8 @@ final class MirrorWindowController: NSWindowController {
   required init?(coder: NSCoder) { fatalError() }
 
   override func close() {
+    screenStatePoller?.invalidate()
+    screenStatePoller = nil
     if let monitor = mouseMonitor {
       NSEvent.removeMonitor(monitor)
       mouseMonitor = nil
@@ -172,10 +188,14 @@ final class MirrorWindowController: NSWindowController {
         }
       }
       // Restore screen power before tearing down so we don't leave the device
-      // dark after disconnect. Use KEYCODE_POWER for compatibility.
+      // dark after disconnect. Use setScreenPowerMode(NORMAL) for a clean wake.
       if isScreenOff, let writer = await session.control {
-        try? await writer.send(.keycode(26, action: .down))  // KEYCODE_POWER down
-        try? await writer.send(.keycode(26, action: .up))    // KEYCODE_POWER up
+        try? await writer.send(.setScreenPowerMode(2))  // NORMAL — restore full power
+      }
+      // Restore device media volume if we muted it for "mac" audio mode.
+      if let serial = deviceSerial, let vol = savedDeviceVolume {
+        try? await adb.shell("media volume --stream 3 --set \(vol)", serial: serial)
+        savedDeviceVolume = nil
       }
       await session.stop()
     }
@@ -201,6 +221,7 @@ final class MirrorWindowController: NSWindowController {
 
     await MainActor.run {
       self.isClipboardSyncing = clipboardOn
+      self.autoScreenOffEnabled = autoScreenOff
       self.eventView.controlSink = { msg in
         Task { try? await writer.send(msg) }
       }
@@ -214,17 +235,31 @@ final class MirrorWindowController: NSWindowController {
       self.window?.toolbar?.validateVisibleItems()
     }
 
-    // Privacy preference — black out the device panel right after the first
+    // Privacy preference — black out the device screen right after the first
     // frame so we don't surprise the user by displaying their lock screen.
-    // Use KEYCODE_POWER for true screen off (not just brightness=0).
-    if autoScreenOff {
-      try? await writer.send(.keycode(26, action: .down))  // KEYCODE_POWER down
-      try? await writer.send(.keycode(26, action: .up))    // KEYCODE_POWER up
+    // Use setScreenPowerMode(0) to keep the virtual display rendering so the
+    // Mac mirror stays alive while the phone panel is dark.
+    // Skipped on session restart — the window already has its real screen state.
+    if !isRestarting, autoScreenOff {
+      try? await writer.send(.setScreenPowerMode(0))  // OFF — panel dark, display still rendering
       await MainActor.run {
         self.isScreenOff = true
         self.window?.toolbar?.validateVisibleItems()
       }
     }
+
+    // Start polling the device's real screen state so the UI stays in sync
+    // even when the user unlocks the phone manually.
+    startScreenStatePoller()
+
+    // Apply the audio-output mode chosen in Settings.  When "mac" is active we
+    // save the phone's current media volume and mute it so audio only plays
+    // from the Mac (no double-sound).  Restored on disconnect / mode change.
+    // Skipped on session restart — the mode was already applied before restart.
+    if !isRestarting {
+      await MainActor.run { self.applyAudioOutput(self.audioOutput) }
+    }
+    isRestarting = false
   }
 
   // MARK: actions (wired from MirrorOverlayBar / window menu / keyboard)
@@ -272,15 +307,14 @@ final class MirrorWindowController: NSWindowController {
   }
 
   @objc private func wakeDevice() {
-    // Use KEYCODE_POWER to properly wake the device screen
-    Task {
-      if let writer = await session.control {
-        try? await writer.send(.keycode(26, action: .down))  // KEYCODE_POWER down
-        try? await writer.send(.keycode(26, action: .up))    // KEYCODE_POWER up
-      }
-    }
+    // Use setScreenPowerMode(NORMAL) to properly wake the device screen
     isScreenOff = false
     window?.toolbar?.validateVisibleItems()
+    Task {
+      if let writer = await session.control {
+        try? await writer.send(.setScreenPowerMode(2))  // NORMAL — wake screen
+      }
+    }
   }
 
   @objc private func sendBack() {
@@ -316,6 +350,8 @@ final class MirrorWindowController: NSWindowController {
   }
 
   /// Cycle audio output: mac → phone → none → mac
+  /// Changing audio mode requires restarting the scrcpy server so the new
+  /// `audioEnabled` flag takes effect on the device side.
   @objc private func cycleAudioOutput() {
     let next: String
     switch audioOutput {
@@ -324,17 +360,132 @@ final class MirrorWindowController: NSWindowController {
     default:      next = "mac"
     }
     audioOutput = next
+    // Restart the session so scrcpy-server starts / stops the audio stream.
+    guard let serial = deviceSerial else { return }
+    isRestarting = true
+    Task { await SessionCoordinator.shared.restartMirror(for: serial) }
+  }
+
+  /// Apply an audio-output mode to both the Mac-side renderer and the device.
+  /// - `"mac"`:   Mac plays audio, device muted (avoid double sound)
+  /// - `"phone"`: Device plays audio, Mac renderer paused
+  /// - `"none"`:  Everything silent
+  private func applyAudioOutput(_ mode: String) {
+    // 1. Mac-side renderer
+    switch mode {
+    case "mac":   session.resumeAudio()
+    default:      session.pauseAudio()
+    }
+
+    // 2. Device-side volume — only touch ADB when the session is live.
+    guard let serial = deviceSerial else { return }
+    Task {
+      switch mode {
+      case "mac":
+        // Save current volume (first time) then mute so we don't get
+        // duplicate audio from both speakers.
+        if savedDeviceVolume == nil {
+          savedDeviceVolume = await fetchDeviceVolume(serial: serial)
+        }
+        await setDeviceVolume(serial: serial, level: 0)
+
+      case "phone":
+        // Restore the original device volume.
+        let level = savedDeviceVolume ?? 7
+        await setDeviceVolume(serial: serial, level: level)
+        savedDeviceVolume = nil
+
+      case "none":
+        if savedDeviceVolume == nil {
+          savedDeviceVolume = await fetchDeviceVolume(serial: serial)
+        }
+        await setDeviceVolume(serial: serial, level: 0)
+
+      default: break
+      }
+    }
+  }
+
+  // MARK: ADB volume helpers
+
+  private func fetchDeviceVolume(serial: String) async -> Int? {
+    do {
+      let out = try await adb.shell("media volume --stream 3 --get", serial: serial)
+      // "Volume is 7" or similar
+      if let r = out.range(of: #"(\d+)"#, options: .regularExpression) {
+        return Int(out[r].filter(\.isNumber))
+      }
+    } catch {}
+    return nil
+  }
+
+  private func setDeviceVolume(serial: String, level: Int) async {
+    do {
+      _ = try await adb.shell("media volume --stream 3 --set \(level)", serial: serial)
+    } catch {}
   }
 
   @objc private func toggleScreenOff() {
-    isScreenOff.toggle()
+    // Flip to the *desired* state — the poller will reconcile if the device
+    // doesn't match (e.g. user already unlocked manually).
+    let turnOff = !isScreenOff
+    isScreenOff = turnOff
+    window?.toolbar?.validateVisibleItems()
     Task {
       if let writer = await session.control {
-        // Use KEYCODE_POWER for true screen on/off
-        try? await writer.send(.keycode(26, action: .down))
-        try? await writer.send(.keycode(26, action: .up))
+        // setScreenPowerMode: 0=OFF (panel dark, display still renders for mirror)
+        //                     2=NORMAL (full wake)
+        try? await writer.send(.setScreenPowerMode(turnOff ? 0 : 2))
       }
     }
+  }
+
+  // MARK: screen-state poller
+
+  /// Poll the phone's real screen state via ADB so `isScreenOff` (and therefore
+  /// the Sleep/Wake button label) always reflects reality — even when the user
+  /// unlocks the device manually.
+  private func startScreenStatePoller() {
+    screenStatePoller?.invalidate()
+    screenStatePoller = Timer.scheduledTimer(withTimeInterval: 3, repeats: true) { [weak self] _ in
+      guard let self, let serial = self.deviceSerial else { return }
+      Task.detached { [weak self] in
+        guard let self else { return }
+        let actuallyOff = await self.queryDeviceScreenOff(serial: serial)
+        let wantsAutoOff = await self.autoScreenOffEnabled
+        await MainActor.run {
+          let changed = self.isScreenOff != actuallyOff
+          if changed {
+            self.isScreenOff = actuallyOff
+            self.window?.toolbar?.validateVisibleItems()
+          }
+          // If autoScreenOff is on and the user just unlocked the phone,
+          // re-apply screen-off so the phone doesn't stay lit.
+          if wantsAutoOff, !actuallyOff {
+            Task {
+              if let writer = await self.session.control {
+                try? await writer.send(.setScreenPowerMode(0))
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /// Returns `true` when the device display is off / dozing.
+  private func queryDeviceScreenOff(serial: String) async -> Bool {
+    do {
+      let out = try await adb.shell("dumpsys power", serial: serial)
+      // mWakefulness: Awake | Asleep | Doze | DozeSuspend
+      if let range = out.range(of: "mWakefulness=") {
+        let value = out[range.upperBound...].prefix { $0.isLetter }
+        return value != "Awake"
+      }
+    } catch {
+      // ADB unavailable or device disconnected — keep current state.
+    }
+    return isScreenOff
   }
 
   @objc private func openFiles() {

--- a/App/Scenes/SettingsView.swift
+++ b/App/Scenes/SettingsView.swift
@@ -41,6 +41,7 @@ private struct MirrorSettings: View {
   @AppStorage("mirror.maxFps") private var maxFps = 30
   @AppStorage("mirror.autoScreenOff") private var autoScreenOff = true
   @AppStorage("mirror.clipboardSync") private var clipboardSync = true
+  @AppStorage("mirror.audioOutput") private var audioOutput = "mac"  // "mac" | "phone" | "none"
 
   var body: some View {
     Form {
@@ -53,6 +54,20 @@ private struct MirrorSettings: View {
         Stepper("Bitrate: \(bitrate) Mbps", value: $bitrate, in: 1...50)
         Stepper("Max FPS: \(maxFps)", value: $maxFps, in: 15...120, step: 5)
         Text("Lower bitrate / FPS = less heat. For 90/120Hz devices, increase FPS for smoother motion. Defaults (4 Mbps / 30 fps) are tuned for thermals.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+      Section("Audio") {
+        Picker("Audio output", selection: $audioOutput) {
+          Text("Mac speakers").tag("mac")
+          Text("Phone speakers / Bluetooth").tag("phone")
+          Text("Mute").tag("none")
+        }
+        Text("""
+          • Mac: play audio through your Mac
+          • Phone: audio stays on the device (use with BT speaker)
+          • Mute: no audio at all
+          """)
           .font(.caption)
           .foregroundStyle(.secondary)
       }

--- a/App/ViewModels/SessionCoordinator.swift
+++ b/App/ViewModels/SessionCoordinator.swift
@@ -401,13 +401,14 @@ final class SessionCoordinator: ObservableObject {
     let codec = (defaults.string(forKey: "mirror.codec") ?? "h265")
     let bitrateMbps = (defaults.object(forKey: "mirror.bitrate") as? Int) ?? 4
     let maxFps = (defaults.object(forKey: "mirror.maxFps") as? Int) ?? 30
+    let audioOutput = defaults.string(forKey: "mirror.audioOutput") ?? "mac"
 
     let options = ScrcpyOptions(
       videoBitRate: bitrateMbps * 1_000_000,
       maxFps: maxFps,
       videoCodec: codec,
       audioCodec: "opus",
-      audioEnabled: true,
+      audioEnabled: audioOutput == "mac",
       controlEnabled: true,
       displayId: displayId
     )

--- a/App/ViewModels/SessionCoordinator.swift
+++ b/App/ViewModels/SessionCoordinator.swift
@@ -416,6 +416,38 @@ final class SessionCoordinator: ObservableObject {
     await controller.bindControl()
   }
 
+  /// Tear down and re-launch the scrcpy session for `serial` without closing
+  /// the mirror window.  Used when a runtime setting (audio output mode)
+  /// changes and requires a new server-side configuration.  The controller's
+  /// `isRestarting` flag is set by the caller so `bindControl()` can skip
+  /// one-shot initialisation (auto-screen-off, audio mute, clipboard reset).
+  func restartMirror(for serial: String) async {
+    guard let controller = mirrorWindows[serial] else { return }
+    pollTasks[serial]?.cancel()
+    pollTasks[serial] = nil
+    let displayId = activePanel[serial]?.id ?? 0
+
+    let device = Device(
+      id: serial,
+      model: await controller.session.deviceName,
+      state: .online
+    )
+
+    await controller.session.stop()
+
+    do {
+      try await launchSession(for: device, displayId: displayId, into: controller)
+      startActiveDisplayPolling(for: device)
+      log.notice("session restarted for \(serial)")
+    } catch {
+      log.error("restart failed for \(serial): \(error)")
+      controller.isRestarting = false
+      controller.close()
+      mirrorWindows.removeValue(forKey: serial)
+      activePanel.removeValue(forKey: serial)
+    }
+  }
+
   // MARK: fold/unfold polling
 
   private func startActiveDisplayPolling(for device: Device) {

--- a/Packages/ADBKit/Sources/ADBKit/ADBConnection.swift
+++ b/Packages/ADBKit/Sources/ADBKit/ADBConnection.swift
@@ -64,16 +64,22 @@ public actor ADBConnection {
     guard count > 0 else { return Data() }
     return try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
       nw.receive(minimumIncompleteLength: count, maximumLength: count) { data, _, isComplete, error in
-        if let error { cont.resume(throwing: error); return }
+        // ENOMSG (errno 96) fires on wireless ADB when the device-side shell
+        // stream closes mid-read. Treat it like an early EOF rather than
+        // propagating a cryptic "No message available on STREAM" to the user.
+        if let error, !Self.isENOMSG(error) {
+          cont.resume(throwing: error); return
+        }
         if let data, data.count == count {
           cont.resume(returning: data)
           return
         }
-        if isComplete {
-          cont.resume(throwing: DroidMirroringError.adbProtocol("eof while reading \(count) bytes"))
+        let got = data?.count ?? 0
+        if error != nil || isComplete {
+          cont.resume(throwing: DroidMirroringError.adbProtocol("eof while reading \(count) bytes (got \(got))"))
           return
         }
-        cont.resume(throwing: DroidMirroringError.adbProtocol("short read: got \(data?.count ?? 0) of \(count)"))
+        cont.resume(throwing: DroidMirroringError.adbProtocol("short read: got \(got) of \(count)"))
       }
     }
   }
@@ -82,7 +88,10 @@ public actor ADBConnection {
   public func readAvailable(maxLength: Int = 64 * 1024) async throws -> Data {
     try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
       nw.receive(minimumIncompleteLength: 1, maximumLength: maxLength) { data, _, _, error in
-        if let error { cont.resume(throwing: error); return }
+        // ENOMSG on wireless ADB → treat as empty read (stream drained).
+        if let error, !Self.isENOMSG(error) {
+          cont.resume(throwing: error); return
+        }
         cont.resume(returning: data ?? Data())
       }
     }
@@ -101,17 +110,38 @@ public actor ADBConnection {
   private func readAvailableOrEOF() async throws -> Data {
     try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
       nw.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { data, _, isComplete, error in
-        if let error { cont.resume(throwing: error); return }
+        // ENOMSG (errno 96, macOS): "No message available on STREAM".
+        // On wireless ADB connections the adb server proxies the device-side
+        // shell over TCP; when the device daemon closes the stream, Network
+        // .framework occasionally surfaces ENOMSG instead of a clean FIN.
+        // This is a benign end-of-stream condition — treat it as EOF so
+        // `dumpsys window`, `pm list packages`, etc. don't blow up.
+        if let error, !Self.isENOMSG(error) {
+          cont.resume(throwing: error); return
+        }
         if let data, !data.isEmpty {
           cont.resume(returning: data); return
         }
-        if isComplete {
+        if isComplete || error != nil {
           cont.resume(returning: Data())
           return
         }
         cont.resume(returning: Data())
       }
     }
+  }
+
+  /// True if `error` is POSIX errno 96 (ENOMSG — "No message of desired type").
+  ///
+  /// This surfaces on wireless ADB (adb WiFi / `adb connect <ip>:<port>`) when
+  /// the device-side adb daemon tears down the shell pseudo-tty after a command
+  /// finishes. The adb TCP proxy relays the close as an ENOMSG rather than a
+  /// clean TCP FIN, depending on timing and OS version (macOS 14/15, iOS 17+).
+  /// The value 96 is the Darwin errno; on Linux ENOMSG is 91 — but this code
+  /// only runs on macOS so 96 is correct.
+  private static func isENOMSG(_ error: Error) -> Bool {
+    let ns = error as NSError
+    return ns.domain == NSPOSIXErrorDomain && ns.code == 96
   }
 
   public func write(_ data: Data) async throws {

--- a/Packages/FusionEngine/Sources/FusionEngine/FusionLauncher.swift
+++ b/Packages/FusionEngine/Sources/FusionEngine/FusionLauncher.swift
@@ -119,17 +119,34 @@ public actor FusionLauncher {
   /// Uses `dumpsys window` (≈5 KB, atomic) instead of `dumpsys display` (≈400 KB,
   /// trips the adb shell stream's POSIX 96 ENOMSG short-read fairly often).
   /// Format: `  Display{#<id> state=<S> size=<W>x<H> ROTATION_<N>}:`
+  ///
+  /// Retries up to 2 times on transient ADB errors — on wireless connections
+  /// even `dumpsys window` can occasionally hit ENOMSG when the device daemon
+  /// closes the shell stream at an unfortunate moment. The retry is cheap
+  /// (~200 ms) and almost always succeeds on the second attempt.
   private func virtualDisplayIds(serial: String) async throws -> Set<Int> {
-    let raw = try await adb.shell("dumpsys window", serial: serial)
-    var ids: Set<Int> = []
-    for line in raw.split(whereSeparator: { $0 == "\n" || $0 == "\r" }) {
-      let s = String(line)
-      guard let range = s.range(of: "Display{#") else { continue }
-      let tail = s[range.upperBound...]
-      let digits = tail.prefix(while: { $0.isNumber })
-      if let id = Int(digits) { ids.insert(id) }
+    var lastError: Error?
+    for attempt in 0..<3 {
+      do {
+        let raw = try await adb.shell("dumpsys window", serial: serial)
+        var ids: Set<Int> = []
+        for line in raw.split(whereSeparator: { $0 == "\n" || $0 == "\r" }) {
+          let s = String(line)
+          guard let range = s.range(of: "Display{#") else { continue }
+          let tail = s[range.upperBound...]
+          let digits = tail.prefix(while: { $0.isNumber })
+          if let id = Int(digits) { ids.insert(id) }
+        }
+        return ids
+      } catch {
+        lastError = error
+        if attempt < 2 {
+          try? await Task.sleep(nanoseconds: 200_000_000)  // 200ms backoff
+          continue
+        }
+      }
     }
-    return ids
+    throw lastError ?? DroidMirroringError.adbProtocol("virtualDisplayIds: unknown failure")
   }
 
   private func resolveNewDisplayId(serial: String, before: Set<Int>) async throws -> Int {

--- a/Packages/MirrorEngine/Sources/MirrorEngine/AudioRenderer.swift
+++ b/Packages/MirrorEngine/Sources/MirrorEngine/AudioRenderer.swift
@@ -28,6 +28,11 @@ public final class AudioRenderer: @unchecked Sendable {
   private let outputFormat: AVAudioFormat
   private var engineStarted = false
 
+  /// True while paused — `feed()` drops packets so the buffer queue doesn't
+  /// grow and old audio doesn't burst out on resume.
+  private var _isPaused = false
+  private let lock = NSLock()
+
   // Per-call state for the AudioConverter input callback.
   private var pendingPacket: Data?
   private var pendingPacketConsumed = false
@@ -84,8 +89,36 @@ public final class AudioRenderer: @unchecked Sendable {
     scratch = nil
   }
 
+  /// Pause playback without tearing down the engine.  Packets keep arriving
+  /// from scrcpy but are silently discarded until `resume()` is called.
+  public func pause() {
+    lock.lock()
+    _isPaused = true
+    lock.unlock()
+    if engineStarted, player.isPlaying { player.pause() }
+  }
+
+  /// Resume playback after `pause()`.  Re-starts the engine if it was stopped.
+  public func resume() {
+    lock.lock()
+    _isPaused = false
+    lock.unlock()
+    if !engineStarted {
+      start()
+      return
+    }
+    if !player.isPlaying { player.play() }
+  }
+
   /// Feed one packet from scrcpy. Config packets carry codec extradata.
   public func feed(packet: Data, isConfig: Bool, pts: CMTime) throws {
+    // While paused, silently drop incoming packets so the queue doesn't grow
+    // and stale audio doesn't burst out when the user resumes.
+    lock.lock()
+    let paused = _isPaused
+    lock.unlock()
+    if paused { return }
+
     if isConfig {
       magicCookie = packet
       if let c = converter {

--- a/Packages/MirrorEngine/Sources/MirrorEngine/MirrorSession.swift
+++ b/Packages/MirrorEngine/Sources/MirrorEngine/MirrorSession.swift
@@ -28,6 +28,17 @@ public final class MirrorSession: @unchecked Sendable {
   public private(set) var deviceMessageReader: DeviceMessageReader?
   public private(set) var audioEnabled: Bool = false
 
+  /// Pause audio playback on the Mac side.  scrcpy still streams audio packets;
+  /// they are silently dropped until `resumeAudio()` is called.
+  public func pauseAudio() {
+    audioRenderer?.pause()
+  }
+
+  /// Resume audio playback on the Mac side after `pauseAudio()`.
+  public func resumeAudio() {
+    audioRenderer?.resume()
+  }
+
   private let frameSink: FrameSink
   private var launcher: ScrcpyServerLauncher?
   private var stream: VideoStream?


### PR DESCRIPTION
### What problem does this solve?

Request from issue #5: users want to choose whether audio plays on Mac speakers, phone speakers, or Bluetooth devices connected to the phone.

### Changes

- **Settings > Mirror**: new 'Audio output' picker with 3 options:
  - **Mac speakers** (default): audio plays through Mac — current behavior
  - **Phone speakers / Bluetooth**: audio stays on the Android device (useful when phone is connected to BT speaker)
  - **Mute**: no audio at all
- **SessionCoordinator**: reads `mirror.audioOutput` from UserDefaults and sets `audioEnabled` accordingly
- Fusion windows already had `audioEnabled: false`, unchanged